### PR TITLE
feat: Improve download handling and haptics

### DIFF
--- a/BHIManager.h
+++ b/BHIManager.h
@@ -45,5 +45,5 @@
 + (void)cleanCache;
 + (BOOL)isEmpty:(NSURL *)url;
 + (NSString *)getDownloadingPersent:(float)per;
-+ (void)saveMedia:(id)item fileExtension:(id)fileExtension;
++ (void)saveMedia:(NSURL *)newFilePath;
 @end

--- a/BHMultipleDownload.h
+++ b/BHMultipleDownload.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 
 @protocol BHMultipleDownloadDelegate <NSObject>
+@optional
+- (void)downloader:(id)downloader didFinishDownloadingFile:(NSURL *)filePath atIndex:(NSInteger)index totalFiles:(NSInteger)total;
 - (void)downloaderProgress:(float)progress;
 - (void)downloaderDidFinishDownloadingAllFiles:(NSMutableArray<NSURL *> *)downloadedFilePaths;
 - (void)downloaderDidFailureWithError:(NSError *)error;

--- a/BHMultipleDownload.m
+++ b/BHMultipleDownload.m
@@ -42,10 +42,14 @@
     NSString *destinationPath = [documentsPath stringByAppendingPathComponent:[NSString stringWithFormat:@"%@-%@", NSUUID.UUID.UUIDString, downloadTask.response.suggestedFilename]];
     
     NSError *error;
-    [[NSFileManager defaultManager] moveItemAtURL:location toURL:[NSURL fileURLWithPath:destinationPath] error:&error];
+    NSURL *destinationURL = [NSURL fileURLWithPath:destinationPath];
+    [[NSFileManager defaultManager] moveItemAtURL:location toURL:destinationURL error:&error];
     
     if (error == nil) {
-        [_downloadedFilePaths addObject:[NSURL fileURLWithPath:destinationPath]];
+        [_downloadedFilePaths addObject:destinationURL];
+        if ([self.delegate respondsToSelector:@selector(downloader:didFinishDownloadingFile:atIndex:totalFiles:)]) {
+            [self.delegate downloader:self didFinishDownloadingFile:destinationURL atIndex:_completedDownloads totalFiles:_totalDownloads];
+        }
     }
     
     _completedDownloads++;

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
-THEOS_PACKAGE_SCHEME = rootless
-TARGET := iphone:clang:16.5:15.0
+THEOS_PACKAGE_SCHEME = roothide
+TARGET := iphone:clang:latest:15.4
 INSTALL_TARGET_PROCESSES = TikTok
 THEOS_DEVICE_IP = 192.168.1.119
-THEOS_DEVICE_USER = root
-ARCHS = arm64
+ARCHS=arm64e
 
 include $(THEOS)/makefiles/common.mk
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-THEOS_PACKAGE_SCHEME = roothide
 TARGET := iphone:clang:latest:15.4
 INSTALL_TARGET_PROCESSES = TikTok
 THEOS_DEVICE_IP = 192.168.1.119
-ARCHS=arm64e
+ARCHS=arm64e arm64
 
 include $(THEOS)/makefiles/common.mk
 

--- a/TikTokHeaders.h
+++ b/TikTokHeaders.h
@@ -81,6 +81,7 @@
 - (NSURL *)recommendUrl;
 - (NSURL *)bestURLtoDownload;
 - (NSString *)bestURLtoDownloadFormat;
+- (NSURL *)bestImageURLtoDownload;
 @end
 
 @interface AWEVideoModel : NSObject

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: com.kunihir0.bhtiktok++
 Name: BHTikTok++
-Version: 1.5
+Version: 1.5.1
 Architecture: iphoneos-arm64
 Description: An awesome tweak for TikTok!
 Maintainer: kunihir0


### PR DESCRIPTION
This commit introduces several fixes and features to enhance the media downloading experience.

Fixes:
- Resolves an issue where single photo downloads would fail by grabbing a video URL. The URL detection logic is now stricter and correctly identifies image formats.
- Fixes a build error caused by `%property` directives by refactoring to use Objective-C associated objects for runtime properties.

Features:
- Implements a new haptic feedback system for downloads:
  - Videos now provide continuous, light "tick" vibrations during download.
  - Album downloads now provide a distinct vibration for each photo as it successfully downloads.
- Refactors all debugging logs to use the modern `os_log` framework for easier filtering and inspection in the Console app.

Other:
- Updates build settings and package version.